### PR TITLE
Allow planting during long-running loan buffs

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -29,11 +29,21 @@ declare global {
     resets: number;
     cookiesPs: number;
     unbuffedCps: number;
+    buffs: Record<string, GameBuff>;
     auraMult: (aura: string) => number;
     Has: (thing: string) => boolean;
     HasUnlocked: (what: string) => number;
+    hasBuff: (buffName: string) => boolean;
     registerMod: (id: string, mod: Record<string, () => void>) => void;
     registerHook: (id: string, hook: () => void) => void;
+  }
+
+  interface GameBuff {
+    name: string;
+    time: number;
+    multCpS?: number;
+    power?: number;
+    [key: string]: any;
   }
 
   interface GameBuilding {


### PR DESCRIPTION
Adds logic to distinguish between temporary CPS buffs (Frenzy, Click Frenzy, etc.) and long-running loan buffs (Loan 1, 2, 3). The mod now allows seed planting during loan buffs as long as no additional temporary buffs are stacked on top.

Closes #1